### PR TITLE
Updated to .NET 7.0 SDK

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0-jammy
+FROM mcr.microsoft.com/dotnet/sdk:7.0-jammy
 
 RUN dotnet --version
 


### PR DESCRIPTION
This pull request updates the Dockerfile to get the .NET 7.0 SDK. This will allow this action to build documentation for apps built for .NET 7.0.